### PR TITLE
Feat: add browse path

### DIFF
--- a/lib/algolia.ex
+++ b/lib/algolia.ex
@@ -102,7 +102,7 @@ defmodule Algolia do
       end
 
 
-    send_request(:read, %{method: :post, path: path, body: body})
+    send_request(:read, %{method: :post, path: path, body: Jason.encode!(body)})
   end
 
   @doc """

--- a/lib/algolia.ex
+++ b/lib/algolia.ex
@@ -96,7 +96,7 @@ defmodule Algolia do
 
     body =
       unless Enum.empty?(params) do
-        %{params: params}
+        %{params: URI.encode_query(params)}
       else
         params
       end

--- a/lib/algolia.ex
+++ b/lib/algolia.ex
@@ -87,6 +87,9 @@ defmodule Algolia do
   end
 
   @doc """
+  Retrieve all objects from an index.
+
+  For all the possible params see https://www.algolia.com/doc/rest-api/search/#browse-index-post
   """
   def browse(index, params \\ %{}) do
     path = Paths.browse(index)

--- a/lib/algolia.ex
+++ b/lib/algolia.ex
@@ -87,6 +87,22 @@ defmodule Algolia do
   end
 
   @doc """
+  """
+  def browse(index, params \\ %{}) do
+    path = Paths.browse(index)
+
+    body =
+      unless Enum.empty?(params) do
+        %{params: params}
+      else
+        params
+      end
+
+
+    send_request(:read, %{method: :post, path: path, body: body})
+  end
+
+  @doc """
   Returns values from the recommend API
 
   See: https://www.algolia.com/doc/rest-api/recommend/?utm_medium=page_link&utm_source=dashboard#get-recommendations

--- a/lib/algolia/paths.ex
+++ b/lib/algolia/paths.ex
@@ -39,6 +39,8 @@ defmodule Algolia.Paths do
     index(index) <> "/facets/" <> URI.encode(facet) <> "/query"
   end
 
+  def browse(index), do: index(index) <> "/browse"
+
   def clear(index), do: index(index) <> "/clear"
 
   def delete_by(index), do: index(index) <> "/deleteByQuery"


### PR DESCRIPTION
# Description 

For Lunaful I need to fetch the objects of the index ordered by whatever is defined on Algolia (in stock, order_score) and get their EAN as we want to place sponsored comments for the top results for marketing. 
It was recommended to use the browse api route not search for stuff like this hence me adding this. 

Also I saw they have a more active elixir Algolia Repo recently might be worth switching over to that instead of using a fork of an unmaintained repo.

See: https://github.com/WTTJ/algoliax